### PR TITLE
Added fusion file extension

### DIFF
--- a/grammars/typoscript2.cson
+++ b/grammars/typoscript2.cson
@@ -2,7 +2,7 @@
 
 'scopeName': 'source.typoscript2'
 
-'fileTypes': [ 'ts2' ]
+'fileTypes': [ 'ts2', 'fusion' ]
 
 'patterns': [{ 'include': '#statement' }]
 


### PR DESCRIPTION
With Flow 4.0/Neos 3.0 TypoScript2 will be renamed to Fusion, the new file extension is now ".fusion".